### PR TITLE
Revert "Handling 404 errors of additional documentation with warnings."

### DIFF
--- a/src/board-explorer-app/board-explorer-app.html
+++ b/src/board-explorer-app/board-explorer-app.html
@@ -1387,16 +1387,12 @@ document.addEventListener("WebComponentsReady", function() {
 
     getDocumentation: function(item, type) {
       return new Promise(function(resolve, reject) {
-
-        if (!item.html) {
-          console.warn("Additional documentation for " + item.refdes + " was not found.");
-          item.html = "";
+        if (item.html) {
+          return resolve({
+            status: 200,
+            content: item.html
+          });
         }
-
-        return resolve({
-          status: 200,
-          content: item.html
-        });
 
         this.$.boardViewer.getDocumentation(item.refdes, type, function(results) {
           if (!results || results.error) {


### PR DESCRIPTION
@juliocri Looks like this is causing content to not load -- eg, [VBAT](https://board-explorer.github.io/board-explorer/#quark_mcu_dev_kit_d2000/VBAT) 

This change reverts Board-Explorer/board-explorer#65